### PR TITLE
Add script for running PetClinic in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# jdk-performance-benchmarks-iceberg
+# JDK Performance Benchmarks - Iceberg
+
+This repository contains a helper script for running the [Spring PetClinic](https://github.com/spring-projects/spring-petclinic) application in Docker with different JDK versions. It can be used to measure the impact of JDK upgrades on the application.
+
+## Prerequisites
+
+- Docker installed on the host machine.
+- Network access to download Docker images and Maven dependencies.
+
+## Usage
+
+Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). By default the application is exposed on port `8080`. You can override the port by setting the environment variable `HOST_PORT`.
+
+```bash
+# Start PetClinic with JDK 11 (default)
+./scripts/run_petclinic.sh
+
+# Start with JDK 8
+./scripts/run_petclinic.sh 8
+
+# Start with JDK 23 on port 9090
+HOST_PORT=9090 ./scripts/run_petclinic.sh 23
+```
+
+When the container is running, access the application at `http://localhost:$HOST_PORT`.
+Press `Ctrl+C` to stop and remove the container.

--- a/scripts/run_petclinic.sh
+++ b/scripts/run_petclinic.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Runs the Spring PetClinic application inside a Docker container using
+# a chosen JDK version. The script downloads the PetClinic source each time
+# the container runs.
+#
+# Usage: ./run_petclinic.sh [JDK_VERSION]
+#   JDK_VERSION can be 8, 11, or 23 (default: 11)
+#
+# Example:
+#   ./run_petclinic.sh 8
+#   ./run_petclinic.sh 23
+
+set -euo pipefail
+
+JDK_VERSION="${1:-11}"
+
+case "$JDK_VERSION" in
+  8)
+    IMAGE="eclipse-temurin:8-jdk-jammy"
+    ;;
+  11)
+    IMAGE="eclipse-temurin:11-jdk-jammy"
+    ;;
+  23)
+    IMAGE="eclipse-temurin:23-jdk-jammy"
+    ;;
+  *)
+    echo "Unsupported JDK version: $JDK_VERSION"
+    echo "Valid versions: 8, 11, 23"
+    exit 1
+    ;;
+esac
+
+# Expose PetClinic on host port 8080
+HOST_PORT=${HOST_PORT:-8080}
+
+cat <<SCRIPT > /tmp/run-petclinic.sh
+set -e
+apt-get update
+apt-get install -y git curl
+
+# Clone the Spring PetClinic source
+rm -rf spring-petclinic
+git clone --depth 1 https://github.com/spring-projects/spring-petclinic.git
+cd spring-petclinic
+
+# Build and run using the Maven wrapper
+./mvnw -q package
+java -jar target/*.jar
+SCRIPT
+
+chmod +x /tmp/run-petclinic.sh
+
+# Run the container and execute the script inside
+exec docker run --rm -it -p ${HOST_PORT}:8080 -v /tmp/run-petclinic.sh:/run-petclinic.sh "$IMAGE" bash /run-petclinic.sh
+


### PR DESCRIPTION
## Summary
- add script `run_petclinic.sh` to download and run Spring PetClinic in a Docker container using JDK 8, 11, or 23
- document prerequisites and usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843148b478083238087825c41dc59b0