### PR TITLE
Add JMeter GitHub Action

### DIFF
--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload JMeter Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jmeter-results
           path: jmeter/results.jtl

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -1,0 +1,49 @@
+name: PetClinic JMeter Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  jmeter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start PetClinic container
+        run: |
+          docker run -d --name petclinic -p 8080:8080 eclipse-temurin:11-jdk-jammy bash -c '
+            set -e
+            apt-get update
+            apt-get install -y git curl > /dev/null
+            git clone --depth 1 https://github.com/spring-projects/spring-petclinic.git
+            cd spring-petclinic
+            ./mvnw -q package
+            java -jar target/*.jar
+          '
+
+      - name: Wait for PetClinic
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:8080 >/dev/null; then
+              echo "PetClinic started"
+              break
+            fi
+            sleep 5
+          done
+
+      - name: Run JMeter test
+        run: |
+          docker run --rm -v ${{ github.workspace }}/jmeter:/tests justb4/jmeter:5.5 -n -t /tests/petclinic.jmx -l /tests/results.jtl
+
+      - name: Stop PetClinic
+        if: always()
+        run: docker rm -f petclinic
+
+      - name: Upload JMeter Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jmeter-results
+          path: jmeter/results.jtl

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ HOST_PORT=9090 ./scripts/run_petclinic.sh 23
 
 When the container is running, access the application at `http://localhost:$HOST_PORT`.
 Press `Ctrl+C` to stop and remove the container.
+
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow that runs the PetClinic application in a container and executes a small JMeter test plan against it. The results of the JMeter run are uploaded as workflow artifacts.

--- a/jmeter/petclinic.jmx
+++ b/jmeter/petclinic.jmx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="PetClinic Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Home Page" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
## Summary
- add CI workflow that starts the PetClinic container and runs JMeter
- include a simple JMeter test plan
- document the CI workflow in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843164978648323a22bbf7adc770955