### PR TITLE
Add JFR helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ HOST_PORT=9090 ./scripts/run_petclinic.sh 23
 When the container is running, access the application at `http://localhost:$HOST_PORT`.
 Press `Ctrl+C` to stop and remove the container.
 
+## Java Flight Recorder
+
+To capture a JFR recording from a running container, use `scripts/start_jfr.sh`.
+Pass the container name or ID, the recording duration in seconds and an optional
+output file name:
+
+```bash
+# Record 60 seconds from the container named "petclinic" and save to myrun.jfr
+./scripts/start_jfr.sh petclinic 60 myrun.jfr
+```
+
+If your container is called `petclinic` (as in the CI workflow), the container
+argument can be omitted.
+
 ## Continuous Integration
 
 The repository includes a GitHub Actions workflow that runs the PetClinic application in a container and executes a small JMeter test plan against it. The results of the JMeter run are uploaded as workflow artifacts.

--- a/scripts/start_jfr.sh
+++ b/scripts/start_jfr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Starts a JFR recording for the running PetClinic container.
+#
+# Usage: ./start_jfr.sh <container> [duration] [output]
+#   container - name or ID of the Docker container (default: petclinic)
+#   duration  - recording length in seconds (default: 60)
+#   output    - filename for the JFR recording (default: recording.jfr)
+
+set -euo pipefail
+
+CONTAINER="${1:-petclinic}"
+DURATION="${2:-60}"
+OUTPUT="${3:-recording.jfr}"
+
+# Determine the Java process ID running PetClinic inside the container
+PID=$(docker exec "$CONTAINER" jcmd | awk '/petclinic/ {print $1; exit}')
+if [ -z "$PID" ]; then
+  echo "Could not find PetClinic process in container $CONTAINER" >&2
+  exit 1
+fi
+
+# Start JFR recording
+docker exec "$CONTAINER" jcmd "$PID" JFR.start duration=${DURATION}s filename=/tmp/$OUTPUT dumponexit=true compress=true
+
+echo "Recording for $DURATION seconds..."
+sleep "$DURATION"
+
+# Copy result to host
+docker cp "$CONTAINER":/tmp/$OUTPUT "$OUTPUT"
+echo "JFR recording saved to $OUTPUT"


### PR DESCRIPTION
## Summary
- add a script to start a JFR session against a running container
- document how to use the JFR helper in the README

## Testing
- `bash -n scripts/start_jfr.sh`

------
https://chatgpt.com/codex/tasks/task_e_68431b2f6aa483239d8c7935854e087f