### PR TITLE
Add GraalVM 23 benchmark comparison

### DIFF
--- a/.github/workflows/graalvm-native.yml
+++ b/.github/workflows/graalvm-native.yml
@@ -1,0 +1,41 @@
+name: PetClinic GraalVM Native Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  graalvm-native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start PetClinic container (GraalVM native)
+        run: |
+          RUN_BACKGROUND=1 CONTAINER_NAME=petclinic ./scripts/run_petclinic.sh graalvm
+
+      - name: Wait for PetClinic
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:8080 >/dev/null; then
+              echo "PetClinic started"
+              break
+            fi
+            sleep 5
+          done
+
+      - name: Run JMeter test
+        run: |
+          docker run --rm -v ${{ github.workspace }}/jmeter:/tests justb4/jmeter:5.5 -n -t /tests/petclinic.jmx -l /tests/results.jtl
+
+      - name: Stop PetClinic
+        if: always()
+        run: docker rm -f petclinic
+
+      - name: Upload JMeter Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmeter-results-native
+          path: jmeter/results.jtl

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a helper script for running the [Spring PetClinic](http
 ## Usage
 
 Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11, 23 or `graalvm`). By default the application is exposed on port `8080`. You can override the port with `HOST_PORT`. When running in the background the container will be named `petclinic` by default which can be changed with `CONTAINER_NAME`.
+When `graalvm` is selected the application is first compiled to a native image using GraalVM's `native-image` tool before running.
 
 ```bash
 # Start PetClinic with JDK 11 (default)
@@ -56,4 +57,4 @@ automatically.
 
 ## Continuous Integration
 
-The repository includes a GitHub Actions workflow that runs the PetClinic application in a container and executes a small JMeter test plan against it. The results of the JMeter run are uploaded as workflow artifacts.
+The repository includes a GitHub Actions workflow that runs the PetClinic application in a container and executes a small JMeter test plan against it. The results of the JMeter run are uploaded as workflow artifacts. A separate workflow `graalvm-native.yml` builds and benchmarks the native image version using GraalVM.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a helper script for running the [Spring PetClinic](http
 
 ## Usage
 
-Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). By default the application is exposed on port `8080`. You can override the port by setting the environment variable `HOST_PORT`.
+Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11, 23 or `graalvm`). By default the application is exposed on port `8080`. You can override the port with `HOST_PORT`. When running in the background the container will be named `petclinic` by default which can be changed with `CONTAINER_NAME`.
 
 ```bash
 # Start PetClinic with JDK 11 (default)
@@ -20,6 +20,9 @@ Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). B
 
 # Start with JDK 23 on port 9090
 HOST_PORT=9090 ./scripts/run_petclinic.sh 23
+
+# Start with GraalVM 23 detached
+RUN_BACKGROUND=1 ./scripts/run_petclinic.sh graalvm
 ```
 
 When the container is running, access the application at `http://localhost:$HOST_PORT`.
@@ -38,6 +41,18 @@ output file name:
 
 If your container is called `petclinic` (as in the CI workflow), the container
 argument can be omitted.
+
+## Comparing JDK 23 with GraalVM 23
+
+`scripts/compare_graalvm.sh` automates running the PetClinic benchmark on both
+JDK 23 and GraalVM 23. It executes the bundled JMeter test plan while collecting
+JFR recordings for each run and places the results under `results/`. If Java
+Mission Control (`jmc`) is available on the host, the recordings are opened
+automatically.
+
+```bash
+./scripts/compare_graalvm.sh
+```
 
 ## Continuous Integration
 

--- a/scripts/compare_graalvm.sh
+++ b/scripts/compare_graalvm.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Compare Spring PetClinic running on JDK 23 and GraalVM 23.
+# Runs a JMeter test plan against each instance while recording
+# Java Flight Recorder data. Results are stored in the "results" directory.
+
+set -euo pipefail
+
+DURATION=${DURATION:-60}
+RESULTS_DIR=${RESULTS_DIR:-results}
+HOST_PORT=${HOST_PORT:-8080}
+CONTAINER_NAME=petclinic
+
+mkdir -p "$RESULTS_DIR"
+
+wait_for_petclinic() {
+  for i in {1..30}; do
+    if curl -s "http://localhost:${HOST_PORT}" >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "PetClinic did not start in time" >&2
+  exit 1
+}
+
+run_benchmark() {
+  local mode="$1" jfr_file="$2" result_file="$3"
+
+  echo "Starting PetClinic using $mode..."
+  if [ "$mode" = "graalvm" ]; then
+    RUN_BACKGROUND=1 CONTAINER_NAME="$CONTAINER_NAME" ./scripts/run_petclinic.sh graalvm > /tmp/petclinic.log 2>&1 &
+  else
+    RUN_BACKGROUND=1 CONTAINER_NAME="$CONTAINER_NAME" ./scripts/run_petclinic.sh 23 > /tmp/petclinic.log 2>&1 &
+  fi
+  pid=$!
+
+  wait_for_petclinic
+
+  ./scripts/start_jfr.sh "$CONTAINER_NAME" "$DURATION" "$RESULTS_DIR/$jfr_file" &
+  jfr_pid=$!
+
+  docker run --rm -v "$(pwd)/jmeter:/tests" justb4/jmeter:5.5 \
+    -n -t /tests/petclinic.jmx -l "$RESULTS_DIR/$result_file"
+
+  wait "$jfr_pid"
+  docker rm -f "$CONTAINER_NAME" >/dev/null
+  wait "$pid" || true
+}
+
+run_benchmark jdk23 jdk23.jfr jdk23.jtl
+run_benchmark graalvm graalvm.jfr graalvm.jtl
+
+cat <<MSG
+JFR recordings created in $RESULTS_DIR
+  JDK 23   -> $RESULTS_DIR/jdk23.jfr
+  GraalVM  -> $RESULTS_DIR/graalvm.jfr
+MSG
+
+if command -v jmc >/dev/null; then
+  jmc "$RESULTS_DIR/jdk23.jfr" "$RESULTS_DIR/graalvm.jfr" &
+else
+  echo "To open the recordings in JMC run:"
+  echo "  jmc $RESULTS_DIR/jdk23.jfr $RESULTS_DIR/graalvm.jfr"
+fi

--- a/scripts/run_petclinic.sh
+++ b/scripts/run_petclinic.sh
@@ -41,10 +41,10 @@ HOST_PORT=${HOST_PORT:-8080}
 CONTAINER_NAME=${CONTAINER_NAME:-petclinic}
 RUN_BACKGROUND=${RUN_BACKGROUND:-0}
 
-cat <<SCRIPT > /tmp/run-petclinic.sh
+cat <<'SCRIPT' > /tmp/run-petclinic.sh
 set -e
-apt-get update
-apt-get install -y git curl
+apt-get update -y
+apt-get install -y git curl >/dev/null
 
 # Clone the Spring PetClinic source
 rm -rf spring-petclinic


### PR DESCRIPTION
## Summary
- support `graalvm` option in `run_petclinic.sh`
- allow background containers for easier automation
- add `compare_graalvm.sh` script to benchmark JDK 23 vs GraalVM 23 with JFR dumps
- document new scripts and options in README

## Testing
- `bash -n scripts/run_petclinic.sh`
- `bash -n scripts/start_jfr.sh`
- `bash -n scripts/compare_graalvm.sh`
- `shellcheck scripts/run_petclinic.sh scripts/start_jfr.sh scripts/compare_graalvm.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684325f53a9883238ccdadb84d004fee