### PR TITLE
Add AppCDS and CRaC modes to PetClinic script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a helper script for running the [Spring PetClinic](http
 
 ## Usage
 
-Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). By default the application is exposed on port `8080`. You can override the port by setting the environment variable `HOST_PORT`.
+Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). A second optional argument enables extra features: `appcds` turns on Application Class-Data Sharing and `crac` starts the application using a CRaC-enabled JDK. By default the application is exposed on port `8080`. You can override the port by setting the environment variable `HOST_PORT`.
 
 ```bash
 # Start PetClinic with JDK 11 (default)
@@ -20,10 +20,22 @@ Run `scripts/run_petclinic.sh` and pass the desired JDK version (8, 11 or 23). B
 
 # Start with JDK 23 on port 9090
 HOST_PORT=9090 ./scripts/run_petclinic.sh 23
+
+# Start with AppCDS enabled
+./scripts/run_petclinic.sh 23 appcds
+
+# Start using a CRaC-enabled JDK
+./scripts/run_petclinic.sh 23 crac
 ```
+
+The `appcds` option generates a class data sharing archive on first startup and
+then runs the application using that archive.
 
 When the container is running, access the application at `http://localhost:$HOST_PORT`.
 Press `Ctrl+C` to stop and remove the container.
+
+When running in `crac` mode the script uses a CRaC-enabled JDK image. Set the
+`CRAC_IMAGE` environment variable to override the Docker image name if needed.
 
 ## Java Flight Recorder
 

--- a/scripts/run_petclinic.sh
+++ b/scripts/run_petclinic.sh
@@ -4,16 +4,25 @@
 # a chosen JDK version. The script downloads the PetClinic source each time
 # the container runs.
 #
-# Usage: ./run_petclinic.sh [JDK_VERSION]
+# Usage: ./run_petclinic.sh [JDK_VERSION] [MODE]
 #   JDK_VERSION can be 8, 11, or 23 (default: 11)
+#   MODE can be "appcds" or "crac" to enable AppCDS or CRaC support
 #
 # Example:
 #   ./run_petclinic.sh 8
-#   ./run_petclinic.sh 23
+#   ./run_petclinic.sh 23 appcds
+#   ./run_petclinic.sh 23 crac
 
 set -euo pipefail
 
 JDK_VERSION="${1:-11}"
+MODE="${2:-}"
+
+if [[ -n "$MODE" && "$MODE" != "appcds" && "$MODE" != "crac" ]]; then
+  echo "Unsupported mode: $MODE"
+  echo "Valid modes: appcds, crac"
+  exit 1
+fi
 
 case "$JDK_VERSION" in
   8)
@@ -32,6 +41,10 @@ case "$JDK_VERSION" in
     ;;
 esac
 
+if [[ "$MODE" == "crac" ]]; then
+  IMAGE="${CRAC_IMAGE:-crac-jdk:17}"
+fi
+
 # Expose PetClinic on host port 8080
 HOST_PORT=${HOST_PORT:-8080}
 
@@ -47,11 +60,32 @@ cd spring-petclinic
 
 # Build and run using the Maven wrapper
 ./mvnw -q package
-java -jar target/*.jar
+
+MODE="$MODE"
+if [ "\$MODE" = "appcds" ]; then
+  java -XX:ArchiveClassesAtExit=/tmp/petclinic.jsa -jar target/*.jar &
+  PID=\$!
+  sleep 30
+  kill \$PID || true
+  java -XX:SharedArchiveFile=/tmp/petclinic.jsa -jar target/*.jar
+elif [ "\$MODE" = "crac" ]; then
+  CHECKPOINT_DIR=/tmp/crac-checkpoint
+  mkdir -p \$CHECKPOINT_DIR
+  java -XX:CRaCCheckpointTo=\$CHECKPOINT_DIR -jar target/*.jar &
+  PID=\$!
+  sleep 30
+  jcmd \$PID JDK.checkpoint
+  java -XX:CRaCRestoreFrom=\$CHECKPOINT_DIR -jar target/*.jar
+else
+  java -jar target/*.jar
+fi
 SCRIPT
 
 chmod +x /tmp/run-petclinic.sh
 
 # Run the container and execute the script inside
-exec docker run --rm -it -p ${HOST_PORT}:8080 -v /tmp/run-petclinic.sh:/run-petclinic.sh "$IMAGE" bash /run-petclinic.sh
+exec docker run --rm -it -p ${HOST_PORT}:8080 \
+  -v /tmp/run-petclinic.sh:/run-petclinic.sh \
+  -e MODE="$MODE" \
+  "$IMAGE" bash /run-petclinic.sh
 


### PR DESCRIPTION
## Summary
- add `appcds` and `crac` modes to `run_petclinic.sh`
- document new script options in README

## Testing
- `bash -n scripts/run_petclinic.sh`
- `bash -n scripts/start_jfr.sh`

------
https://chatgpt.com/codex/tasks/task_e_68432c0fb1808323977733d00216c449