### PR TITLE
Add build matrix workflow for multiple JDKs

### DIFF
--- a/.github/workflows/petclinic-matrix.yml
+++ b/.github/workflows/petclinic-matrix.yml
@@ -1,0 +1,55 @@
+name: PetClinic Build Matrix
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: [ "8", "11", "23", "graalvm", "crac" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start PetClinic container (${{ matrix.jdk }})
+        run: |
+          case "${{ matrix.jdk }}" in
+            crac)
+              ARGS="23 crac"
+              ;;
+            graalvm)
+              ARGS="graalvm"
+              ;;
+            *)
+              ARGS="${{ matrix.jdk }}"
+              ;;
+          esac
+          RUN_BACKGROUND=1 CONTAINER_NAME=petclinic ./scripts/run_petclinic.sh $ARGS
+
+      - name: Wait for PetClinic
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:8080 >/dev/null; then
+              echo "PetClinic started"
+              break
+            fi
+            sleep 5
+          done
+
+      - name: Run JMeter test
+        run: |
+          docker run --rm -v ${{ github.workspace }}/jmeter:/tests justb4/jmeter:5.5 -n -t /tests/petclinic.jmx -l /tests/results.jtl
+
+      - name: Stop PetClinic
+        if: always()
+        run: docker rm -f petclinic
+
+      - name: Upload JMeter Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmeter-results-${{ matrix.jdk }}
+          path: jmeter/results.jtl

--- a/.github/workflows/petclinic-matrix.yml
+++ b/.github/workflows/petclinic-matrix.yml
@@ -19,6 +19,7 @@ jobs:
           case "${{ matrix.jdk }}" in
             crac)
               ARGS="23 crac"
+              CRAC_IMAGE="ghcr.io/crac/openjdk17:latest"
               ;;
             graalvm)
               ARGS="graalvm"
@@ -27,7 +28,7 @@ jobs:
               ARGS="${{ matrix.jdk }}"
               ;;
           esac
-          RUN_BACKGROUND=1 CONTAINER_NAME=petclinic ./scripts/run_petclinic.sh $ARGS
+          RUN_BACKGROUND=1 CONTAINER_NAME=petclinic CRAC_IMAGE="$CRAC_IMAGE" ./scripts/run_petclinic.sh $ARGS
 
       - name: Wait for PetClinic
         run: |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ then runs the application using that archive.
 When the container is running, access the application at `http://localhost:$HOST_PORT`.
 Press `Ctrl+C` to stop and remove the container.
 
-When running in `crac` mode the script uses a CRaC-enabled JDK image. Set the
-`CRAC_IMAGE` environment variable to override the Docker image name if needed.
+When running in `crac` mode the script uses a CRaC-enabled JDK image. By default
+it pulls `ghcr.io/crac/openjdk17:latest`. Set the `CRAC_IMAGE` environment
+variable to override the Docker image name if needed.
 
 ## VisualVM and JMX
 

--- a/scripts/run_petclinic.sh
+++ b/scripts/run_petclinic.sh
@@ -46,7 +46,7 @@ esac
 
 # If CRaC mode selected, allow custom CRaC-enabled image
 if [[ "$MODE" == "crac" ]]; then
-  IMAGE="${CRAC_IMAGE:-crac-jdk:17}"
+  IMAGE="${CRAC_IMAGE:-ghcr.io/crac/openjdk17:latest}"
 fi
 
 # Create the script that will run *inside* the container

--- a/scripts/run_petclinic.sh
+++ b/scripts/run_petclinic.sh
@@ -35,7 +35,7 @@ RUN_BACKGROUND="${RUN_BACKGROUND:-0}"
 case "$JDK_VERSION" in
   8)      IMAGE="eclipse-temurin:8-jdk-jammy" ;;
   11)     IMAGE="eclipse-temurin:11-jdk-jammy" ;;
-  23)     IMAGE="eclipse-temurin:23-jdk-jammy" ;;
+  23)     IMAGE="eclipse-temurin:23-jdk" ;;
   graalvm) IMAGE="ghcr.io/graalvm/jdk:23" ;;
   *)
     echo "Unsupported JDK version: $JDK_VERSION"


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow running PetClinic on JDK 8, 11, 23, GraalVM and CRaC

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684426f716b083239e713de53d87ac04